### PR TITLE
Solucionar Google Analytics con Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
 
     # Build Jekyll into _site
     - uses:  lemonarc/jekyll-action@1.0.0
-    
+      env:
+        JEKYLL_ENV: 'production'
     # Check for build
     - name: Check
       run: ls _site


### PR DESCRIPTION
Este fix debería añadir la variable de entorno `JEKYLL_ENV='production'` a la hora de construir la página en el GitHub Action. Esto [es necesario para que se añadan las analíticas de Google al header](https://github.com/wearearima/blog/blob/master/_includes/head.html#L51).

En mi repositorio de prueba, funciona correctamente. [Un ejemplo](https://github.com/UrkoLekuona/wearearima.github.io/blob/gh-pages/es/2020/05/25/mutation-testing.html#L52).

Era algo en lo que no había caído al hacer el [PR original](https://github.com/wearearima/blog/pull/30). Entiendo que es algo que [hacía GitHub Pages automáticamente](https://stackoverflow.com/a/34607628) al hacer el building, porque nosotros con realizar un commit en `master` nos abstraíamos del building y de las variables de entorno necesarias.