### PR TITLE
deploy: use python 3.11 as runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Manual deployment steps:
 1. `JEKYLL_ENV=production bundle exec jekyll build`
 2. `gcloud app deploy app.yaml`
 
-Ensure your `gcloud` CLI is authenticated and targeting the `blog-arima-eu` project. Keep `_site`, `main.py`, `requirements.txt`, and the committed `.gcloudignore` together when running the deployment so App Engine can serve the generated files.
+Ensure your `gcloud` CLI is authenticated and targeting the `blog-arima-eu` project. Keep `_site`, `main.py`, `requirements.txt`, and the committed `.gcloudignore` together when running the deployment so App Engine can serve the generated files. The runtime currently uses Python 3.11 (see `app.yaml`).
 
 ### Required GCP roles
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: python312
+runtime: python311
 entrypoint: gunicorn -b :$PORT main:app
 
 automatic_scaling:


### PR DESCRIPTION
It seems that Google App Engine doesn't support python 3.12 yet